### PR TITLE
Update Timezone tests and fix "Paris Texas" edge case

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -304,9 +304,10 @@ class TimeSkill(NeonSkill):
         """
         LOG.info(f"Getting tz for locale: {locale}")
         str_locale = locale if isinstance(locale, str) else locale.get("city")
-        for method in (self._get_timezone_from_neon_utils,
+        # Start with known overrides, then go through available utilities
+        for method in (self._get_timezone_from_table,
+                       self._get_timezone_from_neon_utils,
                        self._get_timezone_from_builtins,
-                       self._get_timezone_from_table,
                        self._get_timezone_from_fuzzymatch):
             try:
                 if method == self._get_timezone_from_neon_utils:

--- a/dialog/en-us/timezone.value
+++ b/dialog/en-us/timezone.value
@@ -1,11 +1,12 @@
 # This is a translatable list of values and timezones
-China, Etc/GMT+8
+China, Asia/Hong_Kong
 Kansas City, US/Central
 Central time zone, US/Central
 Central time, US/Central
-Pacific time, US/Pacific-New
-Pacific time zone, US/Pacific-New
-Eastern time, US/Eastern
-Eastern time zone, US/Eastern
-East coast, US/Eastern
-East coast time zone, US/Eastern
+Pacific time, America/Los_Angeles
+Pacific time zone, America/Los_Angeles
+Eastern time, America/New_York
+Eastern time zone, America/New_York
+East coast, America/New_York
+East coast time zone, America/New_York
+Paris Texas, America/Chicago

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -24,7 +24,7 @@ import datetime as dt
 
 from os import mkdir
 from os.path import dirname, join, exists
-
+from pytz import timezone
 from mock import Mock
 from mycroft_bus_client import Message
 from ovos_utils.messagebus import FakeBus
@@ -262,23 +262,26 @@ class TestSkill(unittest.TestCase):
         self.assertEqual(set(call_args[1].keys()), {"date"})
 
     def test_get_timezone(self):
-        from pytz import timezone
-
+        la_timezone = timezone("America/Los_Angeles")
         test_cases = [
-            "seattle",
-            "seattle washington",
-            "seattle, wa",
             {"city": "seattle"},
             {"city": "seattle", "state": "washington"},
             {"city": "seattle", "country": "united states"},
             # "pacific time",
             "los angeles time"
         ]
-        valid_tz = timezone("America/Los_Angeles")
         for case in test_cases:
             tz = self.skill.get_timezone(case)
             self.assertIsInstance(tz, dt.tzinfo)
-            self.assertEqual(tz, valid_tz)
+            self.assertEqual(tz, la_timezone)
+        edge_cases = {
+            "seattle": la_timezone,
+            "seattle washington": la_timezone,
+            "seattle, wa": la_timezone,
+            "paris texas": timezone("America/Chicago")
+        }
+        for case in edge_cases:
+            self.assertEqual(self.skill.get_timezone(case), edge_cases[case])
 
     def test_get_local_datetime(self):
         # TODO
@@ -301,20 +304,26 @@ class TestSkill(unittest.TestCase):
         pass
 
     def test_get_timezone_from_neon_utils(self):
-        # TODO
-        pass
+        self.assertEqual(self.skill._get_timezone_from_neon_utils("seattle"),
+                         timezone("America/Los_Angeles"))
 
     def test_get_timezone_from_builtins(self):
-        # TODO
-        pass
+        self.assertEqual(self.skill._get_timezone_from_builtins("seattle"),
+                         timezone("America/Los_Angeles"))
 
     def test_get_timezone_from_table(self):
-        # TODO
-        pass
+        self.assertEqual(self.skill._get_timezone_from_table("pacific time"),
+                         timezone("America/Los_Angeles"))
+        self.assertEqual(self.skill._get_timezone_from_table("eastern time"),
+                         timezone("America/New_York"))
+        self.assertEqual(self.skill._get_timezone_from_table("china"),
+                         timezone("Asia/Hong_Kong"))
+        self.assertEqual(self.skill._get_timezone_from_table("paris texas"),
+                         timezone("America/Chicago"))
 
     def test_get_timezone_from_fuzzymatch(self):
-        # TODO
-        pass
+        self.assertEqual(self.skill._get_timezone_from_fuzzymatch("seattle"),
+                         timezone("America/Los_Angeles"))
 
 
 if __name__ == '__main__':

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -263,25 +263,25 @@ class TestSkill(unittest.TestCase):
 
     def test_get_timezone(self):
         la_timezone = timezone("America/Los_Angeles")
-        test_cases = [
+        dict_test_cases = [
             {"city": "seattle"},
             {"city": "seattle", "state": "washington"},
             {"city": "seattle", "country": "united states"},
             # "pacific time",
             "los angeles time"
         ]
-        for case in test_cases:
+        for case in dict_test_cases:
             tz = self.skill.get_timezone(case)
             self.assertIsInstance(tz, dt.tzinfo)
             self.assertEqual(tz, la_timezone)
-        edge_cases = {
+        str_test_cases = {
             "seattle": la_timezone,
             "seattle washington": la_timezone,
             "seattle, wa": la_timezone,
             "paris texas": timezone("America/Chicago")
         }
-        for case in edge_cases:
-            self.assertEqual(self.skill.get_timezone(case), edge_cases[case])
+        for case in str_test_cases:
+            self.assertEqual(self.skill.get_timezone(case), str_test_cases[case])
 
     def test_get_local_datetime(self):
         # TODO

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -322,7 +322,7 @@ class TestSkill(unittest.TestCase):
                          timezone("America/Chicago"))
 
     def test_get_timezone_from_fuzzymatch(self):
-        self.assertEqual(self.skill._get_timezone_from_fuzzymatch("seattle"),
+        self.assertEqual(self.skill._get_timezone_from_fuzzymatch("los angeles"),
                          timezone("America/Los_Angeles"))
 
 


### PR DESCRIPTION
Special case "Paris Texas" in timezone.value
Add trivial unit tests of all `get_timezone` methods
Update timezone logic to handle resource overrides first